### PR TITLE
Updated header image

### DIFF
--- a/src/containers/header/header.css
+++ b/src/containers/header/header.css
@@ -111,6 +111,7 @@
 .gpt3__header-image img {
     width: 100%;
     height: 100%;
+    object-fit: contain;
 }
 
 @media screen and (max-width: 1050px) {


### PR DESCRIPTION
When the screen reached around 1300px in width the image would shrink in width, not height.
The image now becomes smaller instead of distorted.