### PR TITLE
Fixed Typo on @media query for .gpt3__blog-container_article-content

### DIFF
--- a/src/components/article/article.css
+++ b/src/components/article/article.css
@@ -55,6 +55,6 @@
 @media screen and (max-width: 550px) {
     .gpt3__blog-container_article-content h3 {
         font-size: 18px;
-        line-height: 25p;
+        line-height: 25px;
     }
 }


### PR DESCRIPTION
Fixed typo on media query from 25p to 25px.