### PR TITLE
fixed_possibility_img_for_less_than_950px_devices

### DIFF
--- a/src/containers/possibility/possibility.css
+++ b/src/containers/possibility/possibility.css
@@ -65,8 +65,8 @@
     }
 
     .gpt3__possibility-image img {
-        width: unset;
-        height: unset;
+        width: 100%;
+        height: 100%;
     }
 
     .gpt3__possibility-content {


### PR DESCRIPTION
I have noticed that the possibility img was not fitting on devices less than 950px 
It was:
`.gpt3__possibility-image img {
        width: unset;
        height: unset;
    }`
So i changed that to:
`.gpt3__possibility-image img {
        width: 100%;
        height: 100%;
    }`
And it worked perfectly.